### PR TITLE
🛠 Fix scaling issue in Diagram on high-DPI and mobile devices

### DIFF
--- a/web/src/components/features/Diagram/Diagram.tsx
+++ b/web/src/components/features/Diagram/Diagram.tsx
@@ -14,22 +14,20 @@ const Diagram = ({ initialDiagram }: DiagramProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [diagram, setDiagram] = useState<IERDiagram>(initialDiagram);
 
-  const [scaleX, setScaleX] = useState(1);
-  const [scaleY, setScaleY] = useState(1);
-
-  const sceneWidth = 710;
-  const sceneHeight = 626;
-
   useEffect(() => {
     setDiagram(initialDiagram);
   }, [initialDiagram]);
 
-  useEffect(() => {
-    if (!ref.current) return;
+  const [sceneWidth, setSceneWidth] = useState(710);
+  const [sceneHeight, setSceneHeight] = useState(626);
 
-    setScaleX(ref.current.offsetWidth / sceneWidth);
-    setScaleY(ref.current.offsetHeight / sceneHeight);
-  }, [ref?.current]);
+  useEffect(() => {
+    if (ref.current) {
+      const bounds = ref.current.getBoundingClientRect();
+      setSceneWidth(bounds.width);
+      setSceneHeight(bounds.height);
+    }
+  }, []);
 
   const handleDragMove = (tableId: string, x: number, y: number) => {
     setDiagram((prevDiagram) => {
@@ -44,16 +42,14 @@ const Diagram = ({ initialDiagram }: DiagramProps) => {
     });
   };
 
-  // const scaleX = (ref?.current?.getBoundingClientRect().width ?? sceneWidth) / sceneWidth;
-  // const scaleY = (ref?.current?.getBoundingClientRect().height ?? sceneHeight) / sceneHeight;
-
   return (
     <div tabIndex={0} className="diagram w-full h-full overflow-hidden cursor-pointer" ref={ref}>
       <Stage
         // quick fix for glitching issue on tabs switching
-        width={sceneWidth * scaleX - 8}
-        height={sceneHeight * scaleY}
-        scale={{ x: scaleX, y: scaleY }}
+        width={sceneWidth}
+        height={sceneHeight}
+        // scale={{ x: scaleX, y: scaleY }}
+        pixelRatio={window.devicePixelRatio}
         draggable>
         <Layer>
           {diagram.tables.map((table) => {

--- a/web/src/components/features/Diagram/Diagram.tsx
+++ b/web/src/components/features/Diagram/Diagram.tsx
@@ -44,13 +44,7 @@ const Diagram = ({ initialDiagram }: DiagramProps) => {
 
   return (
     <div tabIndex={0} className="diagram w-full h-full overflow-hidden cursor-pointer" ref={ref}>
-      <Stage
-        // quick fix for glitching issue on tabs switching
-        width={sceneWidth}
-        height={sceneHeight}
-        // scale={{ x: scaleX, y: scaleY }}
-        pixelRatio={window.devicePixelRatio}
-        draggable>
+      <Stage width={sceneWidth} height={sceneHeight} pixelRatio={window.devicePixelRatio} draggable>
         <Layer>
           {diagram.tables.map((table) => {
             return <Table key={table.id} table={table} onDragMove={handleDragMove} />;

--- a/web/src/components/features/Preview/Preview.tsx
+++ b/web/src/components/features/Preview/Preview.tsx
@@ -18,7 +18,7 @@ interface PreviewProps {
 const Preview = ({ initialDbmlCode = EXAMPLE_DBML }: PreviewProps) => {
   const [dbmlCode, setDbmlCode] = useState<string>(initialDbmlCode);
   const [errors, setErrors] = useState<CompilerDiagnostic[]>([]);
-  const [activeTab, setActiveTab] = useState<'visual' | 'code'>('code');
+  const [activeTab, setActiveTab] = useState<'visual' | 'code'>('visual');
 
   const canCompileDBMLCode = (dbmlCode: string) => {
     try {
@@ -51,6 +51,7 @@ const Preview = ({ initialDbmlCode = EXAMPLE_DBML }: PreviewProps) => {
         className="tab"
         aria-label="Visual"
         onChange={() => setActiveTab('visual')}
+        defaultChecked
       />
       <div className="tab-content bg-base-100 border-base-300 p-6">
         {activeTab === 'visual' && <Diagram initialDiagram={parseDbmlToDiagram(dbmlCode)} />}
@@ -62,7 +63,6 @@ const Preview = ({ initialDbmlCode = EXAMPLE_DBML }: PreviewProps) => {
         className="tab"
         aria-label="DBML Code"
         onChange={() => setActiveTab('code')}
-        defaultChecked
       />
       <div className="tab-content bg-base-100 border-base-300 p-6">
         <DBMLCodeEditor dbmlCode={dbmlCode} onDbmlCodeChange={handleDbmlCodeChange} />


### PR DESCRIPTION
Fix for scaling issue with Diagram mentioned in #52 
- Replaced fixed sceneWidth and sceneHeight with dynamic values based on container size.
- Adjusted canvas rendering using devicePixelRatio to ensure crisp visuals on retina and mobile screens.
- This prevents blurry rendering caused by fractional or downscaled canvas sizes.

Also updated default tab in Preview to be Visual instead of Code.

