### PR TITLE
Add minimal footer to home page

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
       {/* Header */}
       <header className="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
@@ -65,7 +65,7 @@ export default function LandingPage() {
       </header>
 
       {/* Hero Section */}
-      <main className="container mx-auto px-4 py-20">
+      <main className="container mx-auto px-4 py-20 flex-1">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -175,7 +175,7 @@ export default function LandingPage() {
       </main>
 
       {/* Minimal Footer */}
-      <footer className="border-t border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm text-sm py-4">
+      <footer className="bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm text-sm py-4">
         <div className="container mx-auto px-4 flex flex-col md:flex-row items-center justify-between">
           {/* Logo on left */}
           <div className="flex items-center space-x-2">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -174,6 +174,31 @@ export default function LandingPage() {
         </motion.div>
       </main>
 
+      {/* Minimal Footer */}
+      <footer className="border-t border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm text-sm py-4">
+        <div className="container mx-auto px-4 flex flex-col md:flex-row items-center justify-between">
+          {/* Logo on left */}
+          <div className="flex items-center space-x-2">
+            <span className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+              🏗️ scafoldr
+            </span>
+          </div>
+          {/* Placeholder for future links */}
+          <div className="flex items-center space-x-4 mt-2 md:mt-0">
+            {/* GitHub link on right */}
+            <Link
+              href="https://github.com/scafoldr/scafoldr"
+              target="_blank"
+              className="flex items-center space-x-1 hover:underline">
+              <Github className="w-4 h-4" />
+              <span>GitHub</span>
+            </Link>
+            {/* Future social links can go here */}
+            {/* <Link href="#" className="opacity-50 pointer-events-none">Discord (soon)</Link> */}
+          </div>
+        </div>
+      </footer>
+
       {/* Auth Coming Soon Modal */}
       <AuthComingSoonModal open={showAuthModal} onOpenChange={setShowAuthModal} />
     </div>


### PR DESCRIPTION
## 📝 What does this PR do?

This PR adds a minimal, responsive footer to the home page (`src/app/page.tsx`) as described in [scafoldr/scafoldr#61](https://github.com/scafoldr/scafoldr/issues/61).  
- The footer displays the Scafoldr logo on the left and a GitHub repository link on the right.
- It uses lightweight, modern styling with no heavy boxes or shadows.
- The design is responsive and respects the current design system.
- A placeholder is included for future social links (e.g., Discord).

## 📸 Screenshots

_Example:_

_Desktop:_
![Footer screenshot](https://github.com/user-attachments/assets/0cdd8b20-9b71-44a2-bea2-7b7fb34e11d5)

_Mobile:_
![Footer screenshot (mobile)](https://github.com/user-attachments/assets/eb3b9484-cee8-454b-b037-772578d067f2)

## 🔗 Related Issue

Closes #61

## 🧪 How to test

- [ ] Footer is only visible on the home page (`/`)
- [ ] Footer displays the logo on the left
- [ ] Footer displays the GitHub link on the right and opens in a new tab
- [ ] Footer is minimal, non-intrusive, and responsive on all devices
- [ ] No heavy boxes or shadows, matches design language
- [ ] Placeholder for future social links present

## 💭 Additional Notes

- Future social links (Discord, etc.) can be added in the placeholder section.
- This change does not affect any other pages or layouts.

---
