### PR TITLE
feat: add Discord icon and link using simple-icons

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dbml/core": "^3.13.9",
+        "@icons-pack/react-simple-icons": "^13.7.0",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -371,6 +372,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.7.0.tgz",
+      "integrity": "sha512-Vx5mnIm/3gD/9dpCfw/EdCXwzCswmvWnvMjL6zUJTbpk2PuyCdx5zSfiX8KQKYszD/1Z2mfaiBtqCxlHuDcpuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@dbml/core": "^3.13.9",
+    "@icons-pack/react-simple-icons": "^13.7.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { AuthComingSoonModal } from '@/components/coming-soon-modal';
 import { FrameworkSelector } from '@/features/framework-selector';
 import { ArrowRight, Code2, Database, Zap, Github } from 'lucide-react';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 
@@ -194,7 +195,13 @@ export default function LandingPage() {
               <span>GitHub</span>
             </Link>
             {/* Future social links can go here */}
-            {/* <Link href="#" className="opacity-50 pointer-events-none">Discord (soon)</Link> */}
+            <Link
+              href="https://discord.gg/jZPTchaUFB"
+              target="_blank"
+              className="flex items-center space-x-1 hover:underline">
+              <SiDiscord className="w-4 h-4" />
+              <span>Discord</span>
+            </Link>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## 📝 What does this PR do?

Added a Discord icon link to the website footer to provide quick access to the project’s community Discord server.

## 📸 Screenshots (if applicable)

<img width="1356" height="97" alt="Screenshot 2025-09-11 at 13 41 09" src="https://github.com/user-attachments/assets/8f4d53f1-f2f6-451f-9a86-4fb629507b75" />

## 🔗 Related Issue

<!-- Link to the related issue (if applicable) -->
Closes #80 

## 🧪 How to test

<!-- Describe how to test these changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing steps (if applicable):